### PR TITLE
Support for A12Z iPad Pro

### DIFF
--- a/Installer/TrollInstaller/TrollInstaller/exploit/IOGPU.c
+++ b/Installer/TrollInstaller/TrollInstaller/exploit/IOGPU.c
@@ -69,9 +69,11 @@ int IOGPU_get_command_queue_extra_refills_needed(void)
     }
     // iPhone 8, X
     // iPhone XS, XR
+    // iPad Pro A12Z
     else if (
        strstr(u.machine, "iPhone10,")
     || strstr(u.machine, "iPhone11,")
+    || strstr(u.machine, "iPad8,")
     )
     {
         return 3;


### PR DESCRIPTION
Works well on my 4th gen iPad Pro A12Z (WiFi) with value 3.