### PR TITLE
Support for 8th gen iPad (A12)

### DIFF
--- a/Installer/TrollInstaller/TrollInstaller/exploit/IOGPU.c
+++ b/Installer/TrollInstaller/TrollInstaller/exploit/IOGPU.c
@@ -72,10 +72,12 @@ int IOGPU_get_command_queue_extra_refills_needed(void)
     // iPhone 8, X
     // iPhone XS, XR
     // iPad Pro A12Z
+    // iPad 8th Gen
     else if (
        strstr(u.machine, "iPhone10,")
     || strstr(u.machine, "iPhone11,")
     || strstr(u.machine, "iPad8,")
+    || strstr(u.machine, "iPad11,")	
     )
     {
         return 3;


### PR DESCRIPTION
Successfully tested on an 8th gen WiFi iPad (A2270) running iPadOS 15.0.1 (19A348)