### PR TITLE
Use -s to keep entitlements when they're present

### DIFF
--- a/Helper/main.m
+++ b/Helper/main.m
@@ -229,7 +229,7 @@ BOOL signApp(NSString* appPath, NSError** error)
 	else
 	{
 		// app has entitlements, keep them
-		ldidRet = runLdid(@[@"-S", @"-M", certArg, appPath], nil, &errorOutput);
+		ldidRet = runLdid(@[@"-s", certArg, appPath], nil, &errorOutput);
 	}
 
 	NSLog(@"ldid exited with status %d", ldidRet);


### PR DESCRIPTION
With ldid, `-S -M` seems to merge the entitlements with nothing and causes an issue. `-s` is made to keep entitlements. This fix was tested on 15.1 and will properly preserve entitlements.