### PR TITLE
Add note to use SSH Ramdisk in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,8 @@ A proper readme will be added shortly, for now see the release post on [reddit](
 The CoreTrust bug only affects 14.0 - 15.5b4, TrollStore will most likely never support any versions outside that range.
 
 15.2 and up are unsupported currently as there is no way to install TrollStore to these versions until the install method of Fugu15 is public.
+
+NOTE:
+
+If you have a checkm8-vulnerable device (A7-A11) on software versions from 15.2-15.5b4 you can use a SSH Ramdisk.
+Check [this file](install_with_sshrd.md) for more details and a guide.


### PR DESCRIPTION
Simple edit, just added a note to the readme about the ssh ramdisk.

Thank you so much for this awesome tool.