### PR TITLE
Adapt SSHRD install to use new upstream changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The binaries inside an IPA can have arbitary entitlements, fakesign them with ld
 
 ## Banned entitlements
 
-iOS 15 has banned the following three entitlements related to running unsigned code, these are impossible to get without a PPL or PAC bypass, apps signed with them will crash on launch.
+iOS 15 on A12+ has banned the following three entitlements related to running unsigned code, these are impossible to get without a PPL or PAC bypass, apps signed with them will crash on launch.
 
 `com.apple.private.cs.debugger`
 

--- a/install_with_sshrd.md
+++ b/install_with_sshrd.md
@@ -6,7 +6,10 @@ Video tutorial: https://youtu.be/SsvumuaZBT0
 
 1. Run `git clone https://github.com/verygenericname/SSHRD_Script --recursive && cd SSHRD_Script`
 
-2. Run `./sshrd.sh <latestipswlinkhere> TrollStore <uninstallablesystemapphere>` (Tips is the best choice)
+2. Run `./sshrd.sh <iOS version for ramdisk> TrollStore <uninstallable system app>`
+    - Make sure to **not** include the `<>`
+    - 14.3 is the recommended version for the ramdisk, it does not matter what version your device is already on
+    - The uninstallable system app should be an app you don't need to use (e.g. Tips)
 
 3. Run `./sshrd.sh boot` the device should start verbosing and show a TrollFace in ascii, then reboot eventually
 


### PR DESCRIPTION
In this PR, the install with SSHRD guide has been adapted to tell the user to specify an iOS version, instead of an IPSW link, which confused some people.

The readme was also modified to clarify that the banned entitlements are only banned on A12+, since on A11 and lower they will still work (or at least, the app won't crash).