### PR TITLE
Add Hyperlink To Havoc repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Supports jailbroken devices running 14.0 and above.
 
 ### Guide
 
-1. Open your package manager, and make sure Havoc repo (https://havoc.app) is added under Sources, then search for "TrollStore Helper" and install it.
+1. Open your package manager, and make sure [Havoc repo](https://havoc.app) is added under Sources, then search for "TrollStore Helper" and install it.
 
 2. After the installation, respring and a "TrollHelper" app should be on your home screen, launch it.
 


### PR DESCRIPTION
README.md uptated to support Hyperlink on the Havoc Repo.
