### PR TITLE
Adding palera1n to install guides

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,9 +14,9 @@ It works because of an AMFI/CoreTrust bug where iOS does not verify whether or n
 | 14.0 - 14.8.1 | [checkra1n + TrollHelper](./install_trollhelper.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
 | 15.0 - 15.4.1 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
 | 15.5 beta 1 - 4 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
-| 15.5 (RC) | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
+| 15.5 (RC) | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
 | 15.6 beta 1 - 5 | [SSH Ramdisk](./install_sshrd.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
-| 15.6 (RC1/2) and above | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
+| 15.6 (RC1/2) and above | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
 
 This version table is final, TrollStore will never support anything other than the versions listed here. Do not bother asking, if you got a device on an unsupported version, it's best if you forget TrollStore even exists.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It works because of an AMFI/CoreTrust bug where iOS does not verify whether or n
 | 15.5 beta 1 - 4 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
 | 15.5 (RC) | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
 | 15.6 beta 1 - 5 | [SSH Ramdisk](./install_sshrd.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
-| 15.6 (RC1/2) and above | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
+| 15.6 (RC1/2) - 15.7.1 | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
 | 16.0 and above | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
 
 This version table is final, TrollStore will never support anything other than the versions listed here. Do not bother asking, if you got a device on an unsupported version, it's best if you forget TrollStore even exists.

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ It works because of an AMFI/CoreTrust bug where iOS does not verify whether or n
 | 15.5 (RC) | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
 | 15.6 beta 1 - 5 | [SSH Ramdisk](./install_sshrd.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
 | 15.6 (RC1/2) and above | [palera1n + TrollHelper](./install_trollhelper.md) | Not Supported (CT Bug fixed) |
+| 16.0 and above | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
 
 This version table is final, TrollStore will never support anything other than the versions listed here. Do not bother asking, if you got a device on an unsupported version, it's best if you forget TrollStore even exists.
 

--- a/install_trollhelper.md
+++ b/install_trollhelper.md
@@ -2,7 +2,7 @@
 
 **Supported Devices:** All jailbroken devices
 
-**Supported Versions:** iOS 14.0 - 15.5b4, 15.6b1 - 15.6b5
+**Supported Versions:** iOS 14.0 - 15.7.1
 
 ## Guide
 


### PR DESCRIPTION
Using a WIP jailbreak for iOS 15 (checkm8 required) found at https://palera.in, you can install TrollStore through Sileo. Tested on A10 iPod touch running 15.7.1.