### PR TITLE
Update table to account for the new CT bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,13 +10,17 @@ It works because of an AMFI/CoreTrust bug where iOS does not verify whether or n
 
 | Version / Device | arm64 (A8 - A11) | arm64e (A12 - A15, M1) |
 | --- | --- | --- |
-| 13.7 and below | Not Supported (CT Bug only got introduced in 14.0) | Not Supported (CT Bug only got introduced in 14.0) |
+| 13.7 and below | Not Supported (Both CT Bugs only got introduced in 14.0) | Not Supported (Both CT Bugs only got introduced in 14.0) |
 | 14.0 - 14.8.1 | [checkra1n + TrollHelper](./install_trollhelper.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
 | 15.0 - 15.4.1 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
 | 15.5 beta 1 - 4 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
-| 15.5 (RC) | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
-| 15.6 beta 1 - 5 | [SSH Ramdisk](./install_sshrd.md) | [TrollHelperOTA (arm64e)](./install_trollhelperota_arm64e.md) |
-| 15.6 (RC1/2) and above | Not Supported (CT Bug fixed) | Not Supported (CT Bug fixed) |
+| 15.5 | Coming Soon | Coming Soon |
+| 15.6 beta 1 - 5 | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) | [TrollHelperOTA (iOS 15+)](./install_trollhelperota_ios15.md) |
+| 15.6 - 16.5 | Coming Soon | Coming Soon |
+| 16.5.1 - 16.6.1 | Coming Soon | No Installation Method |
+| 16.7 - 16.7.2 | Not Supported (Both CT Bugs fixed) | Not Supported (Both CT Bugs fixed) |
+| 17.0 | Coming Soon | No Installation Method |
+| 17.0.1 and newer | Not Supported (Both CT Bugs fixed) | Not Supported (Both CT Bugs fixed) |
 
 Due to the discovery of a new CoreTrust vulnerability, support for 15.5 - 16.6.1 and 17.0 will be added in the future. Stay on these versions if you want TrollStore. 16.7 and 17.0.1+ will NEVER be supported (unless Apple fucks CoreTrust up a third time...).
 


### PR DESCRIPTION
This PR does the following:
- Updates the table to account for the new CT bug
  - This is done by listing off "Coming Soon" for 15.5, 15.6-16.5, and arm64 16.5.1-16.6.1/17.0, and adding that there is no installation method for arm64e 16.5.1-16.6.1/17.0 at this time
- Switches 15.6b1-15.6b5 to the same entries as other currently supported 15.x versions
  - This is due to the fact that it's been validated that various 15.6 beta versions actually do support the installd bug - even on arm64

Not done in this PR, but something that should probably be done in the future, is to make the "checkra1n + TrollHelper" guide jailbreak-agonistic - such that it can be followed by any jailbreak. This is out of scope for both this PR and probably out of scope until a TS update anyways.

For any aspects changes that you don't entirely agree with, I'm perfectly willing to discuss other ways of implementing these changes and modify this PR as such.