### PR TITLE
Fix Network for Chinese model

### DIFF
--- a/RootHelper/Makefile
+++ b/RootHelper/Makefile
@@ -13,6 +13,7 @@ trollstorehelper_LDFLAGS = -Lexternal/lib -lcrypto -lchoma
 trollstorehelper_CODESIGN_FLAGS = --entitlements entitlements.plist
 trollstorehelper_INSTALL_PATH = /usr/local/bin
 trollstorehelper_LIBRARIES = archive
+trollstorehelper_FRAMEWORKS = CoreTelephony
 trollstorehelper_PRIVATE_FRAMEWORKS = SpringBoardServices BackBoardServices MobileContainerManager
 
 include $(THEOS_MAKE_PATH)/tool.mk

--- a/RootHelper/Makefile
+++ b/RootHelper/Makefile
@@ -13,7 +13,6 @@ trollstorehelper_LDFLAGS = -Lexternal/lib -lcrypto -lchoma
 trollstorehelper_CODESIGN_FLAGS = --entitlements entitlements.plist
 trollstorehelper_INSTALL_PATH = /usr/local/bin
 trollstorehelper_LIBRARIES = archive
-trollstorehelper_FRAMEWORKS = CoreTelephony
 trollstorehelper_PRIVATE_FRAMEWORKS = SpringBoardServices BackBoardServices MobileContainerManager
 
 include $(THEOS_MAKE_PATH)/tool.mk

--- a/Shared/TSUtil.m
+++ b/Shared/TSUtil.m
@@ -7,10 +7,8 @@
 
 static EXPLOIT_TYPE gPlatformVulnerabilities;
 
-@interface PSAppDataUsagePolicyCache : NSObject
-+ (instancetype)sharedInstance;
-- (void)setUsagePoliciesForBundle:(NSString*)bundleId cellular:(BOOL)cellular wifi:(BOOL)wifi;
-@end
+void* _CTServerConnectionCreate(CFAllocatorRef, void *, void *);
+int64_t _CTServerConnectionSetCellularUsagePolicy(CFTypeRef* ct, NSString* identifier, NSDictionary* policies);
 
 #define POSIX_SPAWN_PERSONA_FLAGS_OVERRIDE 1
 extern int posix_spawnattr_set_persona_np(const posix_spawnattr_t* __restrict, uid_t, uint32_t);
@@ -19,14 +17,14 @@ extern int posix_spawnattr_set_persona_gid_np(const posix_spawnattr_t* __restric
 
 void chineseWifiFixup(void)
 {
-	NSBundle *bundle = [NSBundle bundleWithPath:@"/System/Library/PrivateFrameworks/SettingsCellular.framework"];
-	[bundle load];
-
-	PSAppDataUsagePolicyCache* policyCache = [NSClassFromString(@"PSAppDataUsagePolicyCache") sharedInstance];
-	if([policyCache respondsToSelector:@selector(setUsagePoliciesForBundle:cellular:wifi:)])
-	{
-		[policyCache setUsagePoliciesForBundle:NSBundle.mainBundle.bundleIdentifier cellular:true wifi:true];
-	}
+	_CTServerConnectionSetCellularUsagePolicy(
+		_CTServerConnectionCreate(kCFAllocatorDefault, NULL, NULL),
+		NSBundle.mainBundle.bundleIdentifier,
+		@{
+			@"kCTCellularDataUsagePolicy" : @"kCTCellularDataUsagePolicyAlwaysAllow",
+			@"kCTWiFiDataUsagePolicy" : @"kCTCellularDataUsagePolicyAlwaysAllow"
+		}
+	);
 }
 
 NSString *getExecutablePath(void)

--- a/TrollHelper/Makefile
+++ b/TrollHelper/Makefile
@@ -19,7 +19,7 @@ include $(THEOS)/makefiles/common.mk
 APPLICATION_NAME = TrollStorePersistenceHelper
 
 TrollStorePersistenceHelper_FILES = $(wildcard *.m) $(wildcard ../Shared/*.m)
-TrollStorePersistenceHelper_FRAMEWORKS = UIKit CoreGraphics CoreServices
+TrollStorePersistenceHelper_FRAMEWORKS = UIKit CoreGraphics CoreServices CoreTelephony
 TrollStorePersistenceHelper_PRIVATE_FRAMEWORKS = Preferences MobileContainerManager
 TrollStorePersistenceHelper_CFLAGS = -fobjc-arc -I../Shared
 

--- a/TrollHelper/entitlements.plist
+++ b/TrollHelper/entitlements.plist
@@ -6,10 +6,7 @@
 	<string>com.opa334.trollstorepersistencehelper</string>
 	<key>com.apple.CommCenter.fine-grained</key>
 	<array>
-		<string>cellular-plan</string>
-		<string>data-usage</string>
 		<string>data-allowed-write</string>
-		<string>preferences-write</string>
 	</array>
 	<key>com.apple.private.persona-mgmt</key>
 	<true/>

--- a/TrollStore/Makefile
+++ b/TrollStore/Makefile
@@ -9,7 +9,7 @@ include $(THEOS)/makefiles/common.mk
 APPLICATION_NAME = TrollStore
 
 TrollStore_FILES = $(wildcard *.m) $(wildcard ../Shared/*.m)
-TrollStore_FRAMEWORKS = UIKit CoreGraphics CoreServices
+TrollStore_FRAMEWORKS = UIKit CoreGraphics CoreServices CoreTelephony
 TrollStore_PRIVATE_FRAMEWORKS = Preferences MobileIcons MobileContainerManager
 TrollStore_LIBRARIES = archive
 TrollStore_CFLAGS = -fobjc-arc -I../Shared

--- a/TrollStore/entitlements.plist
+++ b/TrollStore/entitlements.plist
@@ -37,10 +37,7 @@
 	<true/>
 	<key>com.apple.CommCenter.fine-grained</key>
 	<array>
-		<string>cellular-plan</string>
-		<string>data-usage</string>
 		<string>data-allowed-write</string>
-		<string>preferences-write</string>
 	</array>
 	<key>com.apple.springboard.opensensitiveurl</key>
 	<true/>


### PR DESCRIPTION
Due to frequent modifications by Apple to the underlying network APIs, which were previously in iOS 12 and iOS 13 and are now in iOS 16, it is advisable for us to decouple from this and utilize a more abstracted layer of API to address network issues. This patch is compatible across iOS 10 to iOS 17.