### PR TITLE
Adjust libarchive include/imports

### DIFF
--- a/RootHelper/unarchive.m
+++ b/RootHelper/unarchive.m
@@ -1,7 +1,7 @@
 #import "unarchive.h"
 
-#include <libarchive/archive.h>
-#include <libarchive/archive_entry.h>
+#include <archive.h>
+#include <archive_entry.h>
 
 static int
 copy_data(struct archive *ar, struct archive *aw)

--- a/TrollStore/TSAppInfo.h
+++ b/TrollStore/TSAppInfo.h
@@ -6,8 +6,8 @@
 //
 
 #import <Foundation/Foundation.h>
-#import <libarchive/archive.h>
-#import <libarchive/archive_entry.h>
+#import <archive.h>
+#import <archive_entry.h>
 @import UIKit;
 
 @interface TSAppInfo : NSObject


### PR DESCRIPTION
Theos previously provided these headers but we have since decided against providing headers vended by their respective authors. In this case, libarchive provides their headers in the `libarchive-dev` package on Linux and the `libarchive` package via Homebrew/MacPorts on OSX (I think).

Relevant theos/headers pr: https://github.com/theos/headers/pull/90