### PR TITLE
CVE-2023-41991 is supported on 16.7 RC (20H18)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,13 +4,13 @@ TrollStore is a permasigned jailed app that can permanently install any IPA you 
 
 It works because of an AMFI/CoreTrust bug where iOS does not correctly verify code signatures of binaries in which there are multiple signers.
 
-Supported versions: 14.0 - 16.6.1, 17.0
+Supported versions: 14.0 - 16.6.1, 16.7 RC (20H18), 17.0
 
 ## Installing TrollStore
 
 For installing TrollStore, refer to the guides at [ios.cfw.guide](https://ios.cfw.guide/installing-trollstore)
 
-16.7.x and 17.0.1+ will NEVER be supported (unless Apple fucks CoreTrust up a third time...).
+16.7.x (excluding 16.7 RC) and 17.0.1+ will NEVER be supported (unless Apple fucks CoreTrust up a third time...).
 
 ## Updating TrollStore
 


### PR DESCRIPTION
Apple moment.

For context: see https://twitter.com/MasterMike88/status/1743974453459956209