### PR TITLE
Add an option to open app with JIT

### DIFF
--- a/JITHelper/Makefile
+++ b/JITHelper/Makefile
@@ -1,0 +1,15 @@
+TARGET := iphone:clang:16.5:14.0
+ARCHS = arm64
+
+TARGET_CODESIGN = ../Exploits/fastPathSign/fastPathSign
+
+include $(THEOS)/makefiles/common.mk
+
+TOOL_NAME = trollstorejithelper
+
+trollstorejithelper_FILES = $(wildcard *.m)
+trollstorejithelper_CODESIGN_FLAGS = --entitlements entitlements.plist
+trollstorejithelper_INSTALL_PATH = /usr/local/bin
+trollstorejithelper_PRIVATE_FRAMEWORKS = RunningBoardServices
+
+include $(THEOS_MAKE_PATH)/tool.mk

--- a/JITHelper/control
+++ b/JITHelper/control
@@ -1,0 +1,9 @@
+Package: com.opa334.trollstorejithelper
+Name: trollstorejithelper
+Version: 2.0.11
+Architecture: iphoneos-arm
+Description: An awesome tool of some sort!!
+Maintainer: opa334
+Author: opa334
+Section: System
+Tag: role::hacker

--- a/JITHelper/entitlements.plist
+++ b/JITHelper/entitlements.plist
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.private.security.container-required</key>
+	<false/>
+	<key>com.apple.private.security.no-sandbox</key>
+	<true/>
+	<key>com.apple.runningboard.process-state</key>
+	<true/>
+	<key>platform-application</key>
+	<true/>
+	<key>task_for_pid-allow</key>
+	<true/>
+</dict>
+</plist>

--- a/JITHelper/main.m
+++ b/JITHelper/main.m
@@ -1,0 +1,41 @@
+@import Foundation;
+@import Darwin;
+
+@interface RBSProcessPredicate
++ (instancetype)predicateMatchingBundleIdentifier:(NSString *)bundleID;
+@end
+
+@interface RBSProcessHandle
++ (instancetype)handleForPredicate:(RBSProcessPredicate *)predicate error:(NSError **)error;
+- (int)rbs_pid;
+@end
+
+#define PT_DETACH       11
+#define PT_ATTACHEXC    14
+int	 ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
+
+int main(int argc, const char* argv[]) {
+	RBSProcessPredicate *predicate = [RBSProcessPredicate predicateMatchingBundleIdentifier:@(argv[1])];
+	RBSProcessHandle* process = [RBSProcessHandle handleForPredicate:predicate error:nil];
+
+	int pid = process.rbs_pid;
+	if (!pid)
+	{
+		return -1;
+	}
+
+	int ret = ptrace(PT_ATTACHEXC, pid, 0, 0);
+	if (ret == -1)
+	{
+		return errno;
+	}
+
+	usleep(100000);
+	ret = ptrace(PT_DETACH, pid, 0, 0);
+	if (ret == -1)
+	{
+		return errno;
+	}
+	return 0;
+}
+

--- a/JITHelper/main.m
+++ b/JITHelper/main.m
@@ -21,7 +21,7 @@ int main(int argc, const char* argv[]) {
 	int pid = process.rbs_pid;
 	if (!pid)
 	{
-		return -1;
+		return ESRCH;
 	}
 
 	int ret = ptrace(PT_ATTACHEXC, pid, 0, 0);

--- a/JITHelper/main.m
+++ b/JITHelper/main.m
@@ -15,10 +15,19 @@
 int	 ptrace(int _request, pid_t _pid, caddr_t _addr, int _data);
 
 int main(int argc, const char* argv[]) {
-	RBSProcessPredicate *predicate = [RBSProcessPredicate predicateMatchingBundleIdentifier:@(argv[1])];
-	RBSProcessHandle* process = [RBSProcessHandle handleForPredicate:predicate error:nil];
+	if (argc != 2)
+	{
+		//NSLog(@"trollstorejithelper invoked with unexpected number of arguments");
+		return -1;
+	}
 
-	int pid = process.rbs_pid;
+	int pid;
+	@autoreleasepool {
+ 		RBSProcessPredicate *predicate = [RBSProcessPredicate predicateMatchingBundleIdentifier:@(argv[1])];
+		RBSProcessHandle* process = [RBSProcessHandle handleForPredicate:predicate error:nil];
+		pid = process.rbs_pid;
+	}
+
 	if (!pid)
 	{
 		return ESRCH;

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 TOPTARGETS := all clean update
 
-$(TOPTARGETS): pre_build make_fastPathSign make_roothelper make_trollstore make_trollhelper_embedded make_trollhelper_package assemble_trollstore build_installer15 build_installer64e
+$(TOPTARGETS): pre_build make_fastPathSign make_jithelper make_roothelper make_trollstore make_trollhelper_embedded make_trollhelper_package assemble_trollstore build_installer15 build_installer64e
 
 pre_build:
 	@rm -rf ./_build 2>/dev/null || true
@@ -8,6 +8,9 @@ pre_build:
 
 make_fastPathSign:
 	@$(MAKE) -C ./Exploits/fastPathSign $(MAKECMDGOALS)
+
+make_jithelper:
+	@$(MAKE) -C ./JITHelper FINALPACKAGE=1 $(MAKECMDGOALS)
 
 make_roothelper:
 	@$(MAKE) -C ./RootHelper FINALPACKAGE=1 $(MAKECMDGOALS)
@@ -39,6 +42,7 @@ make_trollhelper_embedded:
 
 assemble_trollstore:
 	@cp ./RootHelper/.theos/obj/trollstorehelper ./TrollStore/.theos/obj/TrollStore.app/trollstorehelper
+	@cp ./JITHelper/.theos/obj/trollstorejithelper ./TrollStore/.theos/obj/TrollStore.app/trollstorejithelper
 	@cp ./TrollHelper/.theos/obj/TrollStorePersistenceHelper.app/TrollStorePersistenceHelper ./TrollStore/.theos/obj/TrollStore.app/PersistenceHelper
 	@export COPYFILE_DISABLE=1
 	@tar -czvf ./_build/TrollStore.tar -C ./TrollStore/.theos/obj TrollStore.app

--- a/TrollStore/Resources/Info.plist
+++ b/TrollStore/Resources/Info.plist
@@ -190,6 +190,7 @@
 	<false/>
 	<key>TSRootBinaries</key>
 	<array>
+		<string>trollstorejithelper</string>
 		<string>trollstorehelper</string>
 		<string>ldid</string>
 	</array>

--- a/TrollStore/TSAppInfo.h
+++ b/TrollStore/TSAppInfo.h
@@ -50,6 +50,7 @@
 - (NSAttributedString*)detailedInfoTitle;
 - (NSAttributedString*)detailedInfoDescription;
 //- (UIImage*)image;
+- (BOOL)isDebuggable;
 - (void)log;
 
 @end

--- a/TrollStore/TSAppInfo.m
+++ b/TrollStore/TSAppInfo.m
@@ -1165,5 +1165,23 @@ extern UIImage* imageWithSize(UIImage* image, CGSize size);
 	}];
 }
 
+- (BOOL)isDebuggable
+{
+	[self loadEntitlements];
+	__block BOOL debuggable = NO;
+	[self enumerateAllEntitlements:^(NSString *key, NSObject *value, BOOL *stop)
+	{
+		if([key isEqualToString:@"get-task-allow"])
+		{
+			NSNumber* valueNum = (NSNumber*)value;
+			if(valueNum && [valueNum isKindOfClass:NSNumber.class])
+			{
+				debuggable = valueNum.boolValue;
+				*stop = YES;
+			}
+		}
+	}];
+	return debuggable;
+}
 
 @end

--- a/TrollStore/TSAppTableViewController.m
+++ b/TrollStore/TSAppTableViewController.m
@@ -187,7 +187,7 @@ UIImage* imageWithSize(UIImage* image, CGSize size)
 	[TSInstallationController presentInstallationAlertIfEnabledForFile:pathToIPA isRemoteInstall:NO completion:nil];
 }
 
-- (void)openAppPressedForRowAtIndexPath:(NSIndexPath*)indexPath
+- (void)openAppPressedForRowAtIndexPath:(NSIndexPath*)indexPath enableJIT:(BOOL)enableJIT
 {
 	TSApplicationsManager* appsManager = [TSApplicationsManager sharedInstance];
 
@@ -210,6 +210,17 @@ UIImage* imageWithSize(UIImage* image, CGSize size)
 
 		[didFailController addAction:cancelAction];
 		[TSPresentationDelegate presentViewController:didFailController animated:YES completion:nil];
+	}
+	else if (enableJIT)
+	{
+		int ret = [appsManager enableJITForBundleID:appId];
+		if (ret != 0)
+		{
+			UIAlertController* errorAlert = [UIAlertController alertControllerWithTitle:@"Error" message:[NSString stringWithFormat:@"Error enabling JIT: trollstorejithelper returned %d", ret] preferredStyle:UIAlertControllerStyleAlert];
+			UIAlertAction* closeAction = [UIAlertAction actionWithTitle:@"Close" style:UIAlertActionStyleDefault handler:nil];
+			[errorAlert addAction:closeAction];
+			[TSPresentationDelegate presentViewController:errorAlert animated:YES completion:nil];
+		}
 	}
 }
 
@@ -424,10 +435,20 @@ UIImage* imageWithSize(UIImage* image, CGSize size)
 
 	UIAlertAction* openAction = [UIAlertAction actionWithTitle:@"Open" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 	{
-		[self openAppPressedForRowAtIndexPath:indexPath];
+		[self openAppPressedForRowAtIndexPath:indexPath enableJIT:NO];
 		[self deselectRow];
 	}];
 	[appSelectAlert addAction:openAction];
+
+	if ([appInfo isDebuggable])
+	{
+		UIAlertAction* openWithJITAction = [UIAlertAction actionWithTitle:@"Open with JIT" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
+		{
+			[self openAppPressedForRowAtIndexPath:indexPath enableJIT:YES];
+			[self deselectRow];
+		}];
+		[appSelectAlert addAction:openWithJITAction];
+	}
 
 	UIAlertAction* showDetailsAction = [UIAlertAction actionWithTitle:@"Show Details" style:UIAlertActionStyleDefault handler:^(UIAlertAction* action)
 	{

--- a/TrollStore/TSApplicationsManager.h
+++ b/TrollStore/TSApplicationsManager.h
@@ -16,6 +16,7 @@
 - (int)uninstallApp:(NSString*)appId;
 - (int)uninstallAppByPath:(NSString*)path;
 - (BOOL)openApplicationWithBundleID:(NSString *)appID;
+- (int)enableJITForBundleID:(NSString *)appID;
 - (int)changeAppRegistration:(NSString*)appPath toState:(NSString*)newState;
 
 @end

--- a/TrollStore/TSApplicationsManager.m
+++ b/TrollStore/TSApplicationsManager.m
@@ -179,6 +179,13 @@ extern NSUserDefaults* trollStoreUserDefaults();
     return [[LSApplicationWorkspace defaultWorkspace] openApplicationWithBundleID:appId];
 }
 
+- (int)enableJITForBundleID:(NSString *)appId
+{
+    NSString *jitHelperPath = [[NSBundle mainBundle].bundlePath stringByAppendingPathComponent:@"trollstorejithelper"];
+    int ret = spawnRoot(jitHelperPath, @[appId], nil, nil);
+    return ret;
+}
+
 - (int)changeAppRegistration:(NSString*)appPath toState:(NSString*)newState
 {
     if(!appPath || !newState) return -200;


### PR DESCRIPTION
There’s a technique for app to enable JIT itself, but it’s quite unsafe due to requiring sandbox to be disabled. This PR adds a button that lets you enable JIT while keeping app sandboxed.
This works completely standalone using `ptrace(PT_ATTACH_EXT)`, so neither debugserver nor DeveloperDiskImage is required.
Entitlement `task_for_pid-allow` is used, so to make sure root helper doesn’t break on devices where Developer Mode were not enabled, I’ve made another helper, though I haven’t added Developer Mode check for this enable JIT button.