### PR TITLE
App Store Fast Path wasn't introduced until 14.0 beta 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ TrollStore is a permasigned jailed app that can permanently install any IPA you 
 
 It works because of an AMFI/CoreTrust bug where iOS does not correctly verify code signatures of binaries in which there are multiple signers.
 
-Supported versions: 14.0 - 16.6.1, 16.7 RC (20H18), 17.0
+Supported versions: 14.0 beta 2 - 16.6.1, 16.7 RC (20H18), 17.0
 
 ## Installing TrollStore
 


### PR DESCRIPTION
I love when stuff is made even more complicated

Yes there are people still on 14.0 beta 1, and therefore this distinction is warranted.

It could probably be done better, but I'm not sure how best to format that beta 1 is not supported (this is the simplest way to do so, however)