### PR TITLE
Fix inaccurate exploit type identification

### DIFF
--- a/Shared/TSUtil.m
+++ b/Shared/TSUtil.m
@@ -584,26 +584,35 @@ void determinePlatformVulnerableExploitTypes(void *context) {
 	}
 
 
-	if(strncmp(os_build, "19F5070b", 8) <= 0)
-	{
-		// iOS 14.0 - 15.5 beta 4
-		gPlatformVulnerabilities = (EXPLOIT_TYPE_CUSTOM_ROOT_CERTIFICATE_V1 | EXPLOIT_TYPE_CMS_SIGNERINFO_V1);
-	}
-	else if(strncmp(os_build, "19G5027e", 8) >= 0 && strncmp(os_build, "19G5063a", 8) <= 0)
-	{
-		// iOS 15.6 beta 1 - 5
-		gPlatformVulnerabilities = (EXPLOIT_TYPE_CUSTOM_ROOT_CERTIFICATE_V1 | EXPLOIT_TYPE_CMS_SIGNERINFO_V1);
-	}
-	else if(strncmp(os_build, "20H18", 5) <= 0)
-	{
-		// iOS 14.0 - 16.6.1, 16.7 RC
-		gPlatformVulnerabilities = EXPLOIT_TYPE_CMS_SIGNERINFO_V1;
-	}
-	else if(strncmp(os_build, "21A5248v", 8) >= 0 && strncmp(os_build, "21A331", 6) <= 0)
-	{
-		// iOS 17.0
-		gPlatformVulnerabilities = EXPLOIT_TYPE_CMS_SIGNERINFO_V1;
-	}
+    if(strncmp(os_build, "18A5319i", 8) < 0) {
+        // Below iOS 14.0 beta 2
+        gPlatformVulnerabilities = 0;
+    }
+    else if(strncmp(os_build, "21A326", 6) >= 0 && strncmp(os_build, "21A331", 6) <= 0)
+    {
+        // iOS 17.0 final
+        gPlatformVulnerabilities = EXPLOIT_TYPE_CMS_SIGNERINFO_V1;
+    }
+    else if(strncmp(os_build, "21A5248v", 8) >= 0 && strncmp(os_build, "21A5326a", 8) <= 0)
+    {
+        // iOS 17.0 beta 1 - 8
+        gPlatformVulnerabilities = EXPLOIT_TYPE_CMS_SIGNERINFO_V1;
+    }
+    else if(strncmp(os_build, "19G5027e", 8) >= 0 && strncmp(os_build, "19G5063a", 8) <= 0)
+    {
+        // iOS 15.6 beta 1 - 5
+        gPlatformVulnerabilities = (EXPLOIT_TYPE_CUSTOM_ROOT_CERTIFICATE_V1 | EXPLOIT_TYPE_CMS_SIGNERINFO_V1);
+    }
+    else if(strncmp(os_build, "19F5070b", 8) <= 0)
+    {
+        // iOS 14.0 beta 2 - 15.5 beta 4
+        gPlatformVulnerabilities = (EXPLOIT_TYPE_CUSTOM_ROOT_CERTIFICATE_V1 | EXPLOIT_TYPE_CMS_SIGNERINFO_V1);
+    }
+    else if(strncmp(os_build, "20H18", 5) <= 0)
+    {
+        // iOS 14.0 - 16.6.1, 16.7 RC (if CUSTOM_ROOT_CERTIFICATE_V1 not supported)
+        gPlatformVulnerabilities = EXPLOIT_TYPE_CMS_SIGNERINFO_V1;
+    }
 
 	free(os_build);
 }


### PR DESCRIPTION
Fixes an issue which caused incorrect exploit compatibility identification on iOS 17 and newer