### PR TITLE
Check CFBundleSupportedPlatforms before installing apps (and a minor spelling fix)

### DIFF
--- a/RootHelper/main.m
+++ b/RootHelper/main.m
@@ -244,6 +244,10 @@ void setTSURLSchemeState(BOOL newState, NSString* customAppPath)
 	}
 }
 
+NSArray *getCurrentPlatforms(void)
+{
+    return infoDictionaryForAppPath(trollStoreAppPath())[@"CFBundleSupportedPlatforms"];
+}
 #ifdef TROLLSTORE_LITE
 
 BOOL isLdidInstalled(void)
@@ -864,6 +868,7 @@ void applyPatchesToInfoDictionary(NSString* appPath)
 // 174: 
 // 180: tried to sign app where the main binary is encrypted
 // 184: tried to sign app where an additional binary is encrypted
+// 186: application is for the wrong platform
 
 int installApp(NSString* appPackagePath, BOOL sign, BOOL force, BOOL isTSUpdate, BOOL useInstalldMethod, BOOL skipUICache)
 {
@@ -883,6 +888,23 @@ int installApp(NSString* appPackagePath, BOOL sign, BOOL force, BOOL isTSUpdate,
 	}
 
 	if(!infoDictionaryForAppPath(appBundleToInstallPath)) return 172;
+    
+    NSArray* currentPlatforms = getCurrentPlatforms();
+    NSArray* supportedPlatforms = infoDictionaryForAppPath(appBundleToInstallPath)[@"CFBundleSupportedPlatforms"];
+    
+    BOOL platformMatch = NO;
+    for (NSString *platform in supportedPlatforms)
+    {
+        if ([currentPlatforms containsObject:platform])
+        {
+            platformMatch = YES;
+            break;
+        }
+    }
+    
+    if (!platformMatch) return 186;
+    
+    // if (![supportedPlatforms containsObject:@"iPhoneOS"]) return 186;
 
 	if(!isTSUpdate)
 	{

--- a/TrollStore/TSApplicationsManager.m
+++ b/TrollStore/TSApplicationsManager.m
@@ -94,6 +94,7 @@ extern NSUserDefaults* trollStoreUserDefaults();
         break;
         case 186:
         errorDescription = @"The app you tried to install is not supported on this platform. The installation has been prevented as this application will not launch at all if it were to be installed.";
+        break;
     }
 
     NSError* error = [NSError errorWithDomain:TrollStoreErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : errorDescription}];

--- a/TrollStore/TSApplicationsManager.m
+++ b/TrollStore/TSApplicationsManager.m
@@ -91,6 +91,9 @@ extern NSUserDefaults* trollStoreUserDefaults();
         break;
         case 185:
         errorDescription = @"Failed to sign the app. The CoreTrust bypass returned a non zero status code.";
+        break;
+        case 186:
+        errorDescription = @"The app you tried to install is not supported on this platform. The installation has been prevented as this application will not launch at all if it were to be installed.";
     }
 
     NSError* error = [NSError errorWithDomain:TrollStoreErrorDomain code:code userInfo:@{NSLocalizedDescriptionKey : errorDescription}];

--- a/TrollStore/TSSettingsListController.m
+++ b/TrollStore/TSSettingsListController.m
@@ -125,7 +125,7 @@ extern NSUserDefaults* trollStoreUserDefaults(void);
 			utilitiesDescription = @"Apps will be registered as User by default since AppSync Unified is installed.\n\n";
 		}
 		else {
-			utilitiesDescription = @"Apps will be registered as System by default since AppSync Unified is not installed. When apps loose their System registration and stop working, press \"Refresh App Registrations\" here to fix them.\n\n";
+			utilitiesDescription = @"Apps will be registered as System by default since AppSync Unified is not installed. When apps lose their System registration and stop working, press \"Refresh App Registrations\" here to fix them.\n\n";
 		}
 #endif
 		utilitiesDescription = [utilitiesDescription stringByAppendingString:@"If an app does not immediately appear after installation, respring here and it should appear afterwards."];


### PR DESCRIPTION
I'm not entirely sure if the original behavior was technically *intended* or not, but I think my change makes sense to prevent users from attempting to install an app that's not at all compatible with iOS (like a tvOS app, watchOS app, etc.), as I just witnessed someone attempt to do this and figured I should try to correct it.

All I'm doing is cross referencing between TrollStore's own `CFBundleSupportedPlatforms` array and the new app's `CFBundleSupportedPlatforms` array and looking for a match. Hardcoding to look for iPhoneOS in the new app's `CFBundleSupportedPlatforms` array would also work sufficiently.

I also fixed a minor spelling issue in the Settings view while I was at it.

Note:
My testing was done on TrollStore Lite, the CoreTrust bypass seemingly wasn't applying correctly when I was compiling it even though it did say "Applied CoreTrust Bypass!" on the signing stage, not sure if it's an issue on my side or not. Regular TrollStore was just crashing at launch on both devices I was testing on.

<img width="375" height="667" alt="error_186_new" src="https://github.com/user-attachments/assets/f3769e3e-be1a-460f-9292-5bd6ac1e67e8" />